### PR TITLE
added new OIDC structs to convertTo

### DIFF
--- a/api/v1beta1/ocimanagedcontrolplane_conversion.go
+++ b/api/v1beta1/ocimanagedcontrolplane_conversion.go
@@ -25,6 +25,7 @@ import (
 // ConvertTo converts the v1beta1 OCIManagedCluster receiver to a v1beta2 OCIManagedCluster.
 func (src *OCIManagedControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1beta2.OCIManagedControlPlane)
+
 	if err := Convert_v1beta1_OCIManagedControlPlane_To_v1beta2_OCIManagedControlPlane(src, dst, nil); err != nil {
 		return err
 	}
@@ -36,7 +37,9 @@ func (src *OCIManagedControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.ClusterType = restored.Spec.ClusterType
 	dst.Spec.Addons = restored.Spec.Addons
 	dst.Status.AddonStatus = restored.Status.AddonStatus
-	dst.Spec.ClusterOption.OpenIdConnectDiscovery.IsOpenIdConnectDiscoveryEnabled = restored.Spec.ClusterOption.OpenIdConnectDiscovery.IsOpenIdConnectDiscoveryEnabled
+	dst.Spec.ClusterOption.OpenIdConnectDiscovery = restored.Spec.ClusterOption.OpenIdConnectDiscovery
+	dst.Spec.ClusterOption.OpenIdConnectTokenAuthenticationConfig = restored.Spec.ClusterOption.OpenIdConnectTokenAuthenticationConfig
+
 	return nil
 }
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedcontrolplanes.yaml
@@ -324,8 +324,9 @@ spec:
                           in the ID Token with a matching value. Repeat this flag
                           to specify multiple claims.
                         items:
-                          description: KeyValue The properties that define a key value
-                            pair.
+                          description: KeyValue defines the properties that define
+                            a key value pair. This is alias to containerengine.KeyValue,
+                            to support the sdk type
                           properties:
                             key:
                               description: The key of the pair.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedcontrolplanetemplates.yaml
@@ -299,8 +299,9 @@ spec:
                                   to be present in the ID Token with a matching value.
                                   Repeat this flag to specify multiple claims.
                                 items:
-                                  description: KeyValue The properties that define
-                                    a key value pair.
+                                  description: KeyValue defines the properties that
+                                    define a key value pair. This is alias to containerengine.KeyValue,
+                                    to support the sdk type
                                   properties:
                                     key:
                                       description: The key of the pair.


### PR DESCRIPTION
test were failing due to nil pointers on new structs, updated to set structs on `dst` from `restored` for `OpenIdConnectDiscovery` and `OpenIdConnectTokenAuthenticationConfig`